### PR TITLE
Refactor chart colors to use theme tokens

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -23,7 +23,7 @@ const AppLogo = () => (
     <div className="bg-gradient-to-br from-indigo-500 to-purple-600 text-white rounded-full p-1.5 mr-2">
       <Bot size={20} />
     </div>
-    <h1 className="text-lg font-semibold text-gray-800 dark:text-gray-100 flex items-center">
+    <h1 className="text-lg font-semibold text-foreground flex items-center">
       AI Assistant
       <ModelBadge />
     </h1>
@@ -46,7 +46,7 @@ const NavActions = () => (
         href="https://github.com/openai/openai-responses-starter-app"
         target="_blank"
         rel="noopener noreferrer"
-        className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors flex items-center gap-1.5"
+        className="text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1.5"
       >
         <Github size={16} />
         <span>GitHub</span>
@@ -55,7 +55,7 @@ const NavActions = () => (
         href="https://platform.openai.com/docs"
         target="_blank"
         rel="noopener noreferrer"
-        className="text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-100 transition-colors flex items-center gap-1.5"
+        className="text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1.5"
       >
         <BookOpen size={16} />
         <span>Docs</span>
@@ -68,7 +68,7 @@ const NavActions = () => (
 // Configuration panel header component
 const ConfigPanelHeader = () => (
   <div className="p-4 border-b border-gray-100 dark:border-gray-800">
-    <h2 className="text-lg font-medium text-gray-800 dark:text-gray-100 flex items-center">
+    <h2 className="text-lg font-medium text-foreground flex items-center">
       <SparklesIcon size={16} className="text-indigo-600 dark:text-indigo-400 mr-2" />
       Configuration
     </h2>
@@ -86,7 +86,7 @@ const MobileToolsPanel = ({ isOpen, onClose }: MobileToolsPanelProps) =>
     <div className="fixed inset-0 z-50 flex justify-end bg-black bg-opacity-30 backdrop-blur-sm md:hidden">
       <div className="w-[85%] bg-white dark:bg-gray-900 h-full shadow-lg animate-slide-left">
         <div className="p-4 border-b border-gray-100 dark:border-gray-800 flex justify-between items-center">
-          <h2 className="text-lg font-medium text-gray-800 dark:text-gray-100 flex items-center">
+          <h2 className="text-lg font-medium text-foreground flex items-center">
             <SparklesIcon size={16} className="text-indigo-600 dark:text-indigo-400 mr-2" />
             Configuration
           </h2>
@@ -94,7 +94,7 @@ const MobileToolsPanel = ({ isOpen, onClose }: MobileToolsPanelProps) =>
             className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
             onClick={onClose}
           >
-            <X size={20} className="text-gray-800 dark:text-gray-200" />
+            <X size={20} className="text-foreground" />
           </button>
         </div>
         <ContextPanel /> {/* Corrected: Use ContextPanel */}
@@ -107,7 +107,7 @@ const AssistantPlaceholder = () => (
   <div className="flex flex-col h-full">
     {/* Placeholder for Assistant content */}
     <div className="flex-1 p-4">
-      <p className="text-center text-gray-500 dark:text-gray-400">Assistant UI will be here.</p>
+      <p className="text-center text-muted-foreground">Assistant UI will be here.</p>
     </div>
   </div>
 );

--- a/components/dashboard-stats.tsx
+++ b/components/dashboard-stats.tsx
@@ -109,7 +109,14 @@ export function DashboardStats() {
   }))
 
   // Colors for pie chart
-  const COLORS = ["#4f46e5", "#0ea5e9", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6"]
+  const COLORS = [
+    "hsl(var(--chart-1))",
+    "hsl(var(--chart-2))",
+    "hsl(var(--chart-3))",
+    "hsl(var(--chart-4))",
+    "hsl(var(--chart-5))",
+    "hsl(var(--primary))",
+  ]
 
   // Sample data for line chart
   const usageData = [
@@ -143,10 +150,10 @@ export function DashboardStats() {
           </CardContent>
         </Card>
 
-        <Card className="transition-all hover:shadow-md border-l-4 border-l-blue-500">
+        <Card className="transition-all hover:shadow-md border-l-4 border-l-primary">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <Clock className="h-4 w-4 text-blue-500" />
+              <Clock className="h-4 w-4 text-primary" />
               Recently Created
             </CardTitle>
             <CardDescription>Last 7 days</CardDescription>
@@ -156,10 +163,10 @@ export function DashboardStats() {
           </CardContent>
         </Card>
 
-        <Card className="transition-all hover:shadow-md border-l-4 border-l-green-500">
+        <Card className="transition-all hover:shadow-md border-l-4 border-l-primary">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <Tag className="h-4 w-4 text-green-500" />
+              <Tag className="h-4 w-4 text-primary" />
               Categories
             </CardTitle>
             <CardDescription>Total categories</CardDescription>
@@ -169,10 +176,10 @@ export function DashboardStats() {
           </CardContent>
         </Card>
 
-        <Card className="transition-all hover:shadow-md border-l-4 border-l-amber-500">
+        <Card className="transition-all hover:shadow-md border-l-4 border-l-primary">
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium flex items-center gap-2">
-              <TrendingUp className="h-4 w-4 text-amber-500" />
+              <TrendingUp className="h-4 w-4 text-primary" />
               Most Used
             </CardTitle>
             <CardDescription>Top prompt usage</CardDescription>
@@ -217,11 +224,11 @@ export function DashboardStats() {
                       <Tooltip
                         contentStyle={{
                           borderRadius: "8px",
-                          border: "1px solid #e2e8f0",
+                          border: "1px solid hsl(var(--border))",
                           boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
                         }}
                       />
-                      <Bar dataKey="value" fill="#4f46e5" radius={[0, 4, 4, 0]} barSize={20} />
+                      <Bar dataKey="value" fill="hsl(var(--primary))" radius={[0, 4, 4, 0]} barSize={20} />
                     </BarChart>
                   </ResponsiveContainer>
                 ) : (
@@ -250,7 +257,7 @@ export function DashboardStats() {
                       labelLine={false}
                       outerRadius={120}
                       innerRadius={60}
-                      fill="#8884d8"
+                      fill="hsl(var(--primary))"
                       dataKey="value"
                       nameKey="name"
                       label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
@@ -262,7 +269,7 @@ export function DashboardStats() {
                     <Tooltip
                       contentStyle={{
                         borderRadius: "8px",
-                        border: "1px solid #e2e8f0",
+                        border: "1px solid hsl(var(--border))",
                         boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
                       }}
                     />
@@ -282,18 +289,18 @@ export function DashboardStats() {
               <div className="h-80">
                 <ResponsiveContainer width="100%" height="100%">
                   <LineChart data={usageData} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
-                    <CartesianGrid strokeDasharray="3 3" stroke="#e2e8f0" />
+                    <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
                     <XAxis dataKey="month" />
                     <YAxis />
                     <Tooltip
                       contentStyle={{
                         borderRadius: "8px",
-                        border: "1px solid #e2e8f0",
+                        border: "1px solid hsl(var(--border))",
                         boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
                       }}
                     />
                     <Legend />
-                    <Line type="monotone" dataKey="usage" stroke="#4f46e5" strokeWidth={2} activeDot={{ r: 8 }} />
+                    <Line type="monotone" dataKey="usage" stroke="hsl(var(--primary))" strokeWidth={2} activeDot={{ r: 8 }} />
                   </LineChart>
                 </ResponsiveContainer>
               </div>

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -62,7 +62,14 @@ export function Dashboard() {
   ]
 
   // Colors for pie chart
-  const COLORS = ["#0088FE", "#00C49F", "#FFBB28", "#FF8042", "#8884D8", "#82CA9D"]
+  const COLORS = [
+    "hsl(var(--chart-1))",
+    "hsl(var(--chart-2))",
+    "hsl(var(--chart-3))",
+    "hsl(var(--chart-4))",
+    "hsl(var(--chart-5))",
+    "hsl(var(--primary))",
+  ]
 
   // Enhance dashboard responsiveness
   return (
@@ -119,7 +126,7 @@ export function Dashboard() {
                       <XAxis type="number" />
                       <YAxis type="category" dataKey="name" width={100} />
                       <Tooltip />
-                      <Bar dataKey="value" fill="#8884d8" />
+                      <Bar dataKey="value" fill="hsl(var(--primary))" />
                     </BarChart>
                   </ResponsiveContainer>
                 ) : (
@@ -148,7 +155,7 @@ export function Dashboard() {
                       cy="50%"
                       labelLine={false}
                       outerRadius={80}
-                      fill="#8884d8"
+                      fill="hsl(var(--primary))"
                       dataKey="value"
                       nameKey="name"
                       label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}

--- a/components/enhanced-dashboard.tsx
+++ b/components/enhanced-dashboard.tsx
@@ -129,7 +129,14 @@ export function EnhancedDashboard() {
   }))
 
   // Colors for charts
-  const COLORS = ["#4f46e5", "#0ea5e9", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6"]
+  const COLORS = [
+    "hsl(var(--chart-1))",
+    "hsl(var(--chart-2))",
+    "hsl(var(--chart-3))",
+    "hsl(var(--chart-4))",
+    "hsl(var(--chart-5))",
+    "hsl(var(--primary))",
+  ]
 
   return (
     <div className="space-y-8">
@@ -151,7 +158,7 @@ export function EnhancedDashboard() {
           <Card className="transition-all hover:shadow-md hover:border-primary/20">
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium flex items-center gap-2">
-                <Clock className="h-4 w-4 text-blue-500" />
+                <Clock className="h-4 w-4 text-primary" />
                 Recently Created
               </CardTitle>
               <CardDescription>Last 7 days</CardDescription>
@@ -164,7 +171,7 @@ export function EnhancedDashboard() {
           <Card className="transition-all hover:shadow-md hover:border-primary/20">
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium flex items-center gap-2">
-                <Tag className="h-4 w-4 text-green-500" />
+                <Tag className="h-4 w-4 text-primary" />
                 Categories
               </CardTitle>
               <CardDescription>Total categories</CardDescription>
@@ -177,7 +184,7 @@ export function EnhancedDashboard() {
           <Card className="transition-all hover:shadow-md hover:border-primary/20">
             <CardHeader className="pb-2">
               <CardTitle className="text-sm font-medium flex items-center gap-2">
-                <TrendingUp className="h-4 w-4 text-amber-500" />
+                <TrendingUp className="h-4 w-4 text-primary" />
                 Avg. Variables
               </CardTitle>
               <CardDescription>Per prompt</CardDescription>
@@ -247,7 +254,7 @@ export function EnhancedDashboard() {
                               <XAxis type="number" />
                               <YAxis type="category" dataKey="name" width={100} />
                               <Tooltip />
-                              <Bar dataKey="value" fill="#4f46e5" radius={[0, 4, 4, 0]} />
+                              <Bar dataKey="value" fill="hsl(var(--primary))" radius={[0, 4, 4, 0]} />
                             </BarChart>
                           </ResponsiveContainer>
                         ) : chartType === "pie" ? (
@@ -259,7 +266,7 @@ export function EnhancedDashboard() {
                                 cy="50%"
                                 labelLine={false}
                                 outerRadius={100}
-                                fill="#8884d8"
+                                fill="hsl(var(--primary))"
                                 dataKey="value"
                                 nameKey="name"
                                 label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}
@@ -278,7 +285,7 @@ export function EnhancedDashboard() {
                               <XAxis dataKey="name" />
                               <YAxis />
                               <Tooltip />
-                              <Line type="monotone" dataKey="value" stroke="#4f46e5" strokeWidth={2} />
+                              <Line type="monotone" dataKey="value" stroke="hsl(var(--primary))" strokeWidth={2} />
                             </LineChart>
                           </ResponsiveContainer>
                         )
@@ -304,12 +311,12 @@ export function EnhancedDashboard() {
                         <AreaChart data={USAGE_DATA} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
                           <defs>
                             <linearGradient id="colorUsage" x1="0" y1="0" x2="0" y2="1">
-                              <stop offset="5%" stopColor="#4f46e5" stopOpacity={0.8} />
-                              <stop offset="95%" stopColor="#4f46e5" stopOpacity={0} />
+                              <stop offset="5%" stopColor="hsl(var(--primary))" stopOpacity={0.8} />
+                              <stop offset="95%" stopColor="hsl(var(--primary))" stopOpacity={0} />
                             </linearGradient>
                             <linearGradient id="colorCompletion" x1="0" y1="0" x2="0" y2="1">
-                              <stop offset="5%" stopColor="#10b981" stopOpacity={0.8} />
-                              <stop offset="95%" stopColor="#10b981" stopOpacity={0} />
+                              <stop offset="5%" stopColor="hsl(var(--chart-2))" stopOpacity={0.8} />
+                              <stop offset="95%" stopColor="hsl(var(--chart-2))" stopOpacity={0} />
                             </linearGradient>
                           </defs>
                           <XAxis dataKey="month" />
@@ -320,14 +327,14 @@ export function EnhancedDashboard() {
                           <Area
                             type="monotone"
                             dataKey="usage"
-                            stroke="#4f46e5"
+                            stroke="hsl(var(--primary))"
                             fillOpacity={1}
                             fill="url(#colorUsage)"
                           />
                           <Area
                             type="monotone"
                             dataKey="completion"
-                            stroke="#10b981"
+                            stroke="hsl(var(--chart-2))"
                             fillOpacity={1}
                             fill="url(#colorCompletion)"
                           />
@@ -353,8 +360,8 @@ export function EnhancedDashboard() {
                           <YAxis />
                           <Tooltip />
                           <Legend />
-                          <Bar dataKey="created" fill="#4f46e5" name="Created" />
-                          <Bar dataKey="edited" fill="#f59e0b" name="Edited" />
+                          <Bar dataKey="created" fill="hsl(var(--primary))" name="Created" />
+                          <Bar dataKey="edited" fill="hsl(var(--chart-4))" name="Edited" />
                         </BarChart>
                       </ResponsiveContainer>
                     </div>
@@ -379,7 +386,7 @@ export function EnhancedDashboard() {
                       <Tooltip formatter={(value) => [`${value}%`, "Effectiveness"]} />
                       <Bar
                         dataKey="effectiveness"
-                        fill="#4f46e5"
+                        fill="hsl(var(--primary))"
                         radius={[0, 4, 4, 0]}
                         label={{ position: "right", formatter: (value) => `${value}%` }}
                       />
@@ -398,7 +405,7 @@ export function EnhancedDashboard() {
                 <div className="space-y-4">
                   <div className="bg-muted/50 p-4 rounded-lg">
                     <h4 className="font-medium text-sm mb-2 flex items-center gap-2">
-                      <TrendingUp className="h-4 w-4 text-green-500" />
+                      <TrendingUp className="h-4 w-4 text-primary" />
                       Top Performing Category
                     </h4>
                     <p className="text-sm text-muted-foreground">
@@ -408,7 +415,7 @@ export function EnhancedDashboard() {
 
                   <div className="bg-muted/50 p-4 rounded-lg">
                     <h4 className="font-medium text-sm mb-2 flex items-center gap-2">
-                      <Users className="h-4 w-4 text-blue-500" />
+                      <Users className="h-4 w-4 text-primary" />
                       User Engagement
                     </h4>
                     <p className="text-sm text-muted-foreground">

--- a/components/prompt-analytics.tsx
+++ b/components/prompt-analytics.tsx
@@ -57,7 +57,14 @@ export function PromptAnalytics({ promptId }: PromptAnalyticsProps) {
   const [error, setError] = useState<string | null>(null)
   const [timeRange, setTimeRange] = useState<"7d" | "30d" | "90d" | "1y">("30d")
 
-  const COLORS = ["#4f46e5", "#0ea5e9", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6"]
+  const COLORS = [
+    "hsl(var(--chart-1))",
+    "hsl(var(--chart-2))",
+    "hsl(var(--chart-3))",
+    "hsl(var(--chart-4))",
+    "hsl(var(--chart-5))",
+    "hsl(var(--primary))",
+  ]
 
   useEffect(() => {
     const loadAnalytics = async () => {
@@ -217,7 +224,7 @@ export function PromptAnalytics({ promptId }: PromptAnalyticsProps) {
                       <Line
                         type="monotone"
                         dataKey="count"
-                        stroke="#4f46e5"
+                        stroke="hsl(var(--primary))"
                         strokeWidth={2}
                         activeDot={{ r: 8 }}
                         name="Usage Count"
@@ -243,7 +250,7 @@ export function PromptAnalytics({ promptId }: PromptAnalyticsProps) {
                       <XAxis dataKey="hour" />
                       <YAxis />
                       <Tooltip />
-                      <Bar dataKey="count" fill="#4f46e5" name="Usage Count" radius={[4, 4, 0, 0]} />
+                      <Bar dataKey="count" fill="hsl(var(--primary))" name="Usage Count" radius={[4, 4, 0, 0]} />
                     </BarChart>
                   </ResponsiveContainer>
                 </div>
@@ -263,7 +270,7 @@ export function PromptAnalytics({ promptId }: PromptAnalyticsProps) {
                       <XAxis dataKey="day" />
                       <YAxis />
                       <Tooltip />
-                      <Bar dataKey="count" fill="#0ea5e9" name="Usage Count" radius={[4, 4, 0, 0]} />
+                      <Bar dataKey="count" fill="hsl(var(--chart-2))" name="Usage Count" radius={[4, 4, 0, 0]} />
                     </BarChart>
                   </ResponsiveContainer>
                 </div>
@@ -288,7 +295,7 @@ export function PromptAnalytics({ promptId }: PromptAnalyticsProps) {
                           cy="50%"
                           labelLine={false}
                           outerRadius={80}
-                          fill="#8884d8"
+                          fill="hsl(var(--primary))"
                           dataKey="count"
                           nameKey="variable"
                           label={({ name, percent }) => `${name}: ${(percent * 100).toFixed(0)}%`}

--- a/components/prompt-detail.tsx
+++ b/components/prompt-detail.tsx
@@ -121,7 +121,7 @@ export function PromptDetail({ prompt }: PromptDetailProps) {
             aria-label={isFavorited ? "Remove from favorites" : "Add to favorites"}
           >
             {isFavorited ? (
-              <Star className="h-5 w-5 fill-yellow-400 text-yellow-400" />
+              <Star className="h-5 w-5 fill-primary text-primary" />
             ) : (
               <StarOff className="h-5 w-5" />
             )}

--- a/components/tool-call.tsx
+++ b/components/tool-call.tsx
@@ -46,7 +46,7 @@ function ApiCallCell({ toolCall }: ToolCallProps) {
                     marginTop: 0,
                     marginBottom: 8,
                     fontSize: "12px",
-                    backgroundColor: "#1e1e1e", // Dark background regardless of mode
+                    backgroundColor: "hsl(var(--background))", // Dark background regardless of mode
                     border: "1px solid rgba(82, 82, 89, 0.32)"
                   }}
                   language="json"
@@ -68,7 +68,7 @@ function ApiCallCell({ toolCall }: ToolCallProps) {
                       marginTop: 0,
                       marginBottom: 0,
                       fontSize: "12px",
-                      backgroundColor: "#1e1e1e", // Dark background regardless of mode
+                      backgroundColor: "hsl(var(--background))", // Dark background regardless of mode
                       border: "1px solid rgba(82, 82, 89, 0.32)"
                     }}
                     language="json"


### PR DESCRIPTION
## Summary
- use theme CSS vars for chart palettes
- replace icon color classes with theme-based classes
- map dashboard and analytics chart fills to theme tokens
- clean up chat page text colors

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555c5a8c6c83269fe72348726d3bba