### PR TITLE
Add prompt test link to chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project combines the features of a general AI assistant starter app with fu
 - **Streaming Responses** - Real-time streaming of AI responses
 - **Rich Content Display** - Support for markdown, code highlighting, and annotations
 - **Mobile-Friendly Design** - Optimized experience across all devices
+- **Prompt to Chat** - Test a saved prompt in the chat interface with one click
 
 ## 🚀 Technologies
 
@@ -152,6 +153,8 @@ The application includes several pre-built AI functions:
 ### Legal Prompt Management
 
 This feature, originating from the "legal-prompts-app" integration, allows for managing and utilizing a curated list of prompts. While initially designed for legal applications, it can be adapted for various specialized domains requiring predefined prompt templates. The `app/components/legal-prompts-list.tsx` component renders these prompts, with data likely sourced from `scripts/prompts-data.json`.
+
+You can quickly test any saved prompt by clicking the **Test in Chat** button on its detail page. This opens the chat page with the prompt pre-filled in the input field.
 
 ### Responsive Design
 

--- a/app/chat/ChatPageClient.tsx
+++ b/app/chat/ChatPageClient.tsx
@@ -1,0 +1,144 @@
+"use client"
+
+import { PageContainer } from "@/components/layout/page-container"
+import { PageHeader } from "@/components/layout/page-header"
+import { Bot, SparklesIcon, Github, BookOpen, Menu, X } from "lucide-react"
+import { ThemeToggle } from "@/components/theme/theme-toggle"
+import ContextPanel from "@/components/tools-panel" // Corrected: ToolsPanel is default export named ContextPanel
+import { useState } from "react"
+import Assistant from "@/components/assistant" // Added import for Assistant
+
+// Header component for the app
+const AppHeader = () => (
+  <PageHeader
+    title={<AppLogo />}
+    actions={<NavActions />}
+    className="sticky top-0 z-10 bg-background border-b shadow-sm px-4 sm:px-6 lg:px-8"
+  />
+)
+
+// App logo and title component
+const AppLogo = () => (
+  <div className="flex items-center">
+    <div className="bg-gradient-to-br from-indigo-500 to-purple-600 text-white rounded-full p-1.5 mr-2">
+      <Bot size={20} />
+    </div>
+    <h1 className="text-lg font-semibold text-foreground flex items-center">
+      AI Assistant
+      <ModelBadge />
+    </h1>
+  </div>
+)
+
+// Model badge component
+const ModelBadge = () => (
+  <span className="ml-2 bg-gradient-to-r from-indigo-500 to-purple-600 text-white text-xs px-2 py-0.5 rounded-full flex items-center gap-1">
+    <SparklesIcon size={12} />
+    Gemini 2.5 Pro
+  </span>
+)
+
+// Navigation actions component
+const NavActions = () => (
+  <div className="flex items-center space-x-4">
+    <div className="hidden md:flex items-center space-x-4 text-sm">
+      <a
+        href="https://github.com/openai/openai-responses-starter-app"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1.5"
+      >
+        <Github size={16} />
+        <span>GitHub</span>
+      </a>
+      <a
+        href="https://platform.openai.com/docs"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1.5"
+      >
+        <BookOpen size={16} />
+        <span>Docs</span>
+      </a>
+    </div>
+    <ThemeToggle />
+  </div>
+)
+
+// Configuration panel header component
+const ConfigPanelHeader = () => (
+  <div className="p-4 border-b border-gray-100 dark:border-gray-800">
+    <h2 className="text-lg font-medium text-foreground flex items-center">
+      <SparklesIcon size={16} className="text-indigo-600 dark:text-indigo-400 mr-2" />
+      Configuration
+    </h2>
+  </div>
+)
+
+// Mobile tools panel component
+interface MobileToolsPanelProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+const MobileToolsPanel = ({ isOpen, onClose }: MobileToolsPanelProps) =>
+  isOpen ? (
+    <div className="fixed inset-0 z-50 flex justify-end bg-black bg-opacity-30 backdrop-blur-sm md:hidden">
+      <div className="w-[85%] bg-white dark:bg-gray-900 h-full shadow-lg animate-slide-left">
+        <div className="p-4 border-b border-gray-100 dark:border-gray-800 flex justify-between items-center">
+          <h2 className="text-lg font-medium text-foreground flex items-center">
+            <SparklesIcon size={16} className="text-indigo-600 dark:text-indigo-400 mr-2" />
+            Configuration
+          </h2>
+          <button
+            className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            onClick={onClose}
+          >
+            <X size={20} className="text-foreground" />
+          </button>
+        </div>
+        <ContextPanel /> {/* Corrected: Use ContextPanel */}
+      </div>
+    </div>
+  ) : null
+
+
+// Main component
+interface ChatPageClientProps {
+  initialPrompt?: string
+}
+
+export default function ChatPageClient({ initialPrompt }: ChatPageClientProps) {
+  const [isToolsPanelOpen, setIsToolsPanelOpen] = useState(false)
+
+  return (
+    <div className="flex flex-col justify-center min-h-screen bg-gradient-to-b from-gray-50 via-white to-gray-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800">
+      <AppHeader />
+
+      {/* Main Content */}
+      <div className="flex flex-1 w-full max-w-7xl mx-auto shadow-sm border border-gray-200 dark:border-gray-700 rounded-lg my-4 overflow-hidden">
+        <div className="w-full md:w-[70%] border-r border-gray-100 dark:border-gray-800">
+          <Assistant initialInputMessage={initialPrompt} />
+        </div>
+        <div className="hidden md:block w-[30%] bg-white dark:bg-gray-900">
+          <ConfigPanelHeader />
+          <ContextPanel />
+        </div>
+
+        {/* Mobile menu button */}
+        <div className="fixed bottom-4 right-4 md:hidden z-40">
+          <button
+            onClick={() => setIsToolsPanelOpen(true)}
+            className="bg-gradient-to-br from-indigo-500 to-purple-600 text-white p-3 rounded-full shadow-lg hover:opacity-90 transition-all"
+            aria-label="Open settings"
+          >
+            <Menu size={20} />
+          </button>
+        </div>
+
+        {/* Mobile tools panel */}
+        <MobileToolsPanel isOpen={isToolsPanelOpen} onClose={() => setIsToolsPanelOpen(false)} />
+      </div>
+    </div>
+  )
+}

--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,149 +1,20 @@
-"use client"
+import ChatPageClient from "./ChatPageClient"
+import { getLegalPromptById } from "@/app/actions"
 
-import { PageContainer } from "@/components/layout/page-container"
-import { PageHeader } from "@/components/layout/page-header"
-import { Bot, SparklesIcon, Github, BookOpen, Menu, X } from "lucide-react"
-import { ThemeToggle } from "@/components/theme/theme-toggle"
-import ContextPanel from "@/components/tools-panel" // Corrected: ToolsPanel is default export named ContextPanel
-import { useState } from "react"
-import Assistant from "@/components/assistant" // Added import for Assistant
-
-// Header component for the app
-const AppHeader = () => (
-  <PageHeader
-    title={<AppLogo />}
-    actions={<NavActions />}
-    className="sticky top-0 z-10 bg-background border-b shadow-sm px-4 sm:px-6 lg:px-8"
-  />
-)
-
-// App logo and title component
-const AppLogo = () => (
-  <div className="flex items-center">
-    <div className="bg-gradient-to-br from-indigo-500 to-purple-600 text-white rounded-full p-1.5 mr-2">
-      <Bot size={20} />
-    </div>
-    <h1 className="text-lg font-semibold text-foreground flex items-center">
-      AI Assistant
-      <ModelBadge />
-    </h1>
-  </div>
-)
-
-// Model badge component
-const ModelBadge = () => (
-  <span className="ml-2 bg-gradient-to-r from-indigo-500 to-purple-600 text-white text-xs px-2 py-0.5 rounded-full flex items-center gap-1">
-    <SparklesIcon size={12} />
-    Gemini 2.5 Pro
-  </span>
-)
-
-// Navigation actions component
-const NavActions = () => (
-  <div className="flex items-center space-x-4">
-    <div className="hidden md:flex items-center space-x-4 text-sm">
-      <a
-        href="https://github.com/openai/openai-responses-starter-app"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1.5"
-      >
-        <Github size={16} />
-        <span>GitHub</span>
-      </a>
-      <a
-        href="https://platform.openai.com/docs"
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-muted-foreground hover:text-foreground transition-colors flex items-center gap-1.5"
-      >
-        <BookOpen size={16} />
-        <span>Docs</span>
-      </a>
-    </div>
-    <ThemeToggle />
-  </div>
-)
-
-// Configuration panel header component
-const ConfigPanelHeader = () => (
-  <div className="p-4 border-b border-gray-100 dark:border-gray-800">
-    <h2 className="text-lg font-medium text-foreground flex items-center">
-      <SparklesIcon size={16} className="text-indigo-600 dark:text-indigo-400 mr-2" />
-      Configuration
-    </h2>
-  </div>
-)
-
-// Mobile tools panel component
-interface MobileToolsPanelProps {
-  isOpen: boolean
-  onClose: () => void
+interface ChatPageProps {
+  searchParams?: {
+    promptId?: string
+  }
 }
 
-const MobileToolsPanel = ({ isOpen, onClose }: MobileToolsPanelProps) =>
-  isOpen ? (
-    <div className="fixed inset-0 z-50 flex justify-end bg-black bg-opacity-30 backdrop-blur-sm md:hidden">
-      <div className="w-[85%] bg-white dark:bg-gray-900 h-full shadow-lg animate-slide-left">
-        <div className="p-4 border-b border-gray-100 dark:border-gray-800 flex justify-between items-center">
-          <h2 className="text-lg font-medium text-foreground flex items-center">
-            <SparklesIcon size={16} className="text-indigo-600 dark:text-indigo-400 mr-2" />
-            Configuration
-          </h2>
-          <button
-            className="p-1.5 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-            onClick={onClose}
-          >
-            <X size={20} className="text-foreground" />
-          </button>
-        </div>
-        <ContextPanel /> {/* Corrected: Use ContextPanel */}
-      </div>
-    </div>
-  ) : null
-
-// Placeholder Assistant component
-const AssistantPlaceholder = () => (
-  <div className="flex flex-col h-full">
-    {/* Placeholder for Assistant content */}
-    <div className="flex-1 p-4">
-      <p className="text-center text-muted-foreground">Assistant UI will be here.</p>
-    </div>
-  </div>
-);
-
-// Main component
-export default function ChatPage() {
-  const [isToolsPanelOpen, setIsToolsPanelOpen] = useState(false)
-
-  return (
-    <div className="flex flex-col justify-center min-h-screen bg-gradient-to-b from-gray-50 via-white to-gray-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800">
-      <AppHeader />
-
-      {/* Main Content */}
-      <div className="flex flex-1 w-full max-w-7xl mx-auto shadow-sm border border-gray-200 dark:border-gray-700 rounded-lg my-4 overflow-hidden">
-        <div className="w-full md:w-[70%] border-r border-gray-100 dark:border-gray-800">
-          <AssistantPlaceholder />
-        </div>
-        <div className="hidden md:block w-[30%] bg-white dark:bg-gray-900">
-          <ConfigPanelHeader />
-          <ContextPanel />
-        </div>
-
-        {/* Mobile menu button */}
-        <div className="fixed bottom-4 right-4 md:hidden z-40">
-          <button
-            onClick={() => setIsToolsPanelOpen(true)}
-            className="bg-gradient-to-br from-indigo-500 to-purple-600 text-white p-3 rounded-full shadow-lg hover:opacity-90 transition-all"
-            aria-label="Open settings"
-          >
-            <Menu size={20} />
-          </button>
-        </div>
-
-        {/* Mobile tools panel */}
-        <MobileToolsPanel isOpen={isToolsPanelOpen} onClose={() => setIsToolsPanelOpen(false)} />
-      </div>
-    </div>
-  )
+export default async function ChatPage({ searchParams }: ChatPageProps) {
+  const id = Number.parseInt(searchParams?.promptId ?? "")
+  let promptText: string | undefined
+  if (!isNaN(id)) {
+    const prompt = await getLegalPromptById(id)
+    if (prompt) {
+      promptText = prompt.prompt
+    }
+  }
+  return <ChatPageClient initialPrompt={promptText} />
 }

--- a/app/prompts/[id]/page.tsx
+++ b/app/prompts/[id]/page.tsx
@@ -81,7 +81,7 @@ async function PromptDataView({ promptId }: { promptId: number }) {
                   Edit
                 </Button>
               </Link>
-              <Link href="/chat" passHref>
+              <Link href={`/chat?promptId=${promptId}`} passHref>
                 <Button variant="outline">
                   <MessageSquare className="h-4 w-4 mr-2" />
                   Test in Chat

--- a/components/assistant.tsx
+++ b/components/assistant.tsx
@@ -4,7 +4,11 @@ import Chat from "./chat";
 import useConversationStore from "@/stores/useConversationStore";
 import { Item, processMessages } from "@/lib/assistant";
 
-export default function Assistant() {
+interface AssistantProps {
+  initialInputMessage?: string
+}
+
+export default function Assistant({ initialInputMessage }: AssistantProps) {
   const { chatMessages, addConversationItem, addChatMessage } =
     useConversationStore();
   const [isLoading, setIsLoading] = useState(false);
@@ -37,10 +41,11 @@ export default function Assistant() {
   return (
     <div className="h-full w-full bg-white flex justify-center">
       <div className="w-full max-w-4xl">
-        <Chat 
-          items={chatMessages} 
-          onSendMessage={handleSendMessage} 
+        <Chat
+          items={chatMessages}
+          onSendMessage={handleSendMessage}
           isLoading={isLoading}
+          initialInputMessage={initialInputMessage}
         />
       </div>
     </div>

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -11,11 +11,12 @@ interface ChatProps {
   items: Item[];
   onSendMessage: (message: string) => void;
   isLoading?: boolean;
+  initialInputMessage?: string;
 }
 
-const Chat: React.FC<ChatProps> = ({ items, onSendMessage, isLoading = false }) => {
+const Chat: React.FC<ChatProps> = ({ items, onSendMessage, isLoading = false, initialInputMessage = "" }) => {
   const itemsEndRef = useRef<HTMLDivElement>(null);
-  const [inputMessageText, setinputMessageText] = useState<string>("");
+  const [inputMessageText, setinputMessageText] = useState<string>(initialInputMessage);
   // This state is used to provide better user experience for non-English IMEs such as Japanese
   const [isComposing, setIsComposing] = useState(false);
 


### PR DESCRIPTION
## Summary
- enable testing prompts in Chat
- prefill chat input when `promptId` is specified
- document how to test prompts via chat

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars' in many files)*
- `npm run type-check` *(fails: Missing script)*
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_6855675dc848832693ba9a5d59b740dc