### PR TITLE
Add chat prompt selector

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -7,6 +7,7 @@ import { ThemeToggle } from "@/components/theme/theme-toggle"
 import ContextPanel from "@/components/tools-panel" // Corrected: ToolsPanel is default export named ContextPanel
 import { useState } from "react"
 import Assistant from "@/components/assistant" // Added import for Assistant
+import ChatPromptSelector from "@/components/chat-prompt-selector"
 
 // Header component for the app
 const AppHeader = () => (
@@ -101,20 +102,10 @@ const MobileToolsPanel = ({ isOpen, onClose }: MobileToolsPanelProps) =>
       </div>
     </div>
   ) : null
-
-// Placeholder Assistant component
-const AssistantPlaceholder = () => (
-  <div className="flex flex-col h-full">
-    {/* Placeholder for Assistant content */}
-    <div className="flex-1 p-4">
-      <p className="text-center text-muted-foreground">Assistant UI will be here.</p>
-    </div>
-  </div>
-);
-
 // Main component
 export default function ChatPage() {
   const [isToolsPanelOpen, setIsToolsPanelOpen] = useState(false)
+  const [selectedPrompt, setSelectedPrompt] = useState("")
 
   return (
     <div className="flex flex-col justify-center min-h-screen bg-gradient-to-b from-gray-50 via-white to-gray-50 dark:from-gray-900 dark:via-gray-900 dark:to-gray-800">
@@ -123,7 +114,10 @@ export default function ChatPage() {
       {/* Main Content */}
       <div className="flex flex-1 w-full max-w-7xl mx-auto shadow-sm border border-gray-200 dark:border-gray-700 rounded-lg my-4 overflow-hidden">
         <div className="w-full md:w-[70%] border-r border-gray-100 dark:border-gray-800">
-          <AssistantPlaceholder />
+          <Assistant
+            prefill={selectedPrompt}
+            renderAboveInput={<ChatPromptSelector onSelect={setSelectedPrompt} />}
+          />
         </div>
         <div className="hidden md:block w-[30%] bg-white dark:bg-gray-900">
           <ConfigPanelHeader />

--- a/components/assistant.tsx
+++ b/components/assistant.tsx
@@ -4,7 +4,7 @@ import Chat from "./chat";
 import useConversationStore from "@/stores/useConversationStore";
 import { Item, processMessages } from "@/lib/assistant";
 
-export default function Assistant() {
+export default function Assistant({ prefill, renderAboveInput }: { prefill?: string; renderAboveInput?: React.ReactNode }) {
   const { chatMessages, addConversationItem, addChatMessage } =
     useConversationStore();
   const [isLoading, setIsLoading] = useState(false);
@@ -37,10 +37,12 @@ export default function Assistant() {
   return (
     <div className="h-full w-full bg-white flex justify-center">
       <div className="w-full max-w-4xl">
-        <Chat 
-          items={chatMessages} 
-          onSendMessage={handleSendMessage} 
+        <Chat
+          items={chatMessages}
+          onSendMessage={handleSendMessage}
           isLoading={isLoading}
+          prefill={prefill}
+          renderAboveInput={renderAboveInput}
         />
       </div>
     </div>

--- a/components/chat-prompt-selector.tsx
+++ b/components/chat-prompt-selector.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { getPrompts, type LegalPrompt } from "@/app/actions"
+import { Combobox } from "@/components/ui/combobox"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+import { useFavorites } from "@/components/favorites-provider"
+
+interface ChatPromptSelectorProps {
+  onSelect: (promptText: string) => void
+}
+
+export default function ChatPromptSelector({ onSelect }: ChatPromptSelectorProps) {
+  const [prompts, setPrompts] = useState<LegalPrompt[]>([])
+  const [selectedId, setSelectedId] = useState("")
+  const [category, setCategory] = useState("")
+  const [showFavorites, setShowFavorites] = useState(false)
+  const { isFavorite } = useFavorites()
+
+  useEffect(() => {
+    ;(async () => {
+      const { prompts } = await getPrompts()
+      setPrompts(prompts)
+    })()
+  }, [])
+
+  const categories = Array.from(new Set(prompts.map(p => p.category))).filter(Boolean)
+  const filtered = prompts.filter(
+    p => (!category || p.category === category) && (!showFavorites || isFavorite(p.id)),
+  )
+
+  const options = filtered.map(p => ({ value: p.id.toString(), label: p.name }))
+
+  const handleChange = (id: string) => {
+    setSelectedId(id)
+    const prompt = prompts.find(p => p.id.toString() === id)
+    if (prompt) {
+      onSelect(prompt.prompt)
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-3">
+        <Select value={category} onValueChange={setCategory}>
+          <SelectTrigger className="w-full sm:max-w-xs">
+            <SelectValue placeholder="All categories" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="">All categories</SelectItem>
+            {categories.map(c => (
+              <SelectItem key={c} value={c}>
+                {c}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <div className="flex items-center gap-2">
+          <Switch id="fav-switch" checked={showFavorites} onCheckedChange={setShowFavorites} />
+          <Label htmlFor="fav-switch" className="text-sm">
+            Favorites
+          </Label>
+        </div>
+      </div>
+      <Combobox
+        options={options}
+        value={selectedId}
+        onChange={handleChange}
+        placeholder="Choose a prompt..."
+        emptyMessage="No prompts found"
+        className="w-full"
+      />
+    </div>
+  )
+}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -8,14 +8,23 @@ import { Item } from "@/lib/assistant";
 import { Bot, Loader, Send, Sparkles } from "lucide-react";
 
 interface ChatProps {
-  items: Item[];
-  onSendMessage: (message: string) => void;
-  isLoading?: boolean;
+  items: Item[]
+  onSendMessage: (message: string) => void
+  isLoading?: boolean
+  prefill?: string
+  renderAboveInput?: React.ReactNode
 }
 
-const Chat: React.FC<ChatProps> = ({ items, onSendMessage, isLoading = false }) => {
-  const itemsEndRef = useRef<HTMLDivElement>(null);
-  const [inputMessageText, setinputMessageText] = useState<string>("");
+const Chat: React.FC<ChatProps> = ({
+  items,
+  onSendMessage,
+  isLoading = false,
+  prefill = "",
+  renderAboveInput,
+}) => {
+  const itemsEndRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null)
+  const [inputMessageText, setinputMessageText] = useState<string>(prefill)
   // This state is used to provide better user experience for non-English IMEs such as Japanese
   const [isComposing, setIsComposing] = useState(false);
 
@@ -34,6 +43,17 @@ const Chat: React.FC<ChatProps> = ({ items, onSendMessage, isLoading = false }) 
   useEffect(() => {
     scrollToBottom();
   }, [items]);
+
+  useEffect(() => {
+    if (prefill) {
+      setinputMessageText(prefill)
+      if (textareaRef.current) {
+        const ta = textareaRef.current
+        ta.style.height = 'auto'
+        ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`
+      }
+    }
+  }, [prefill])
 
   return (
     <div className="flex justify-center items-center size-full">
@@ -93,10 +113,12 @@ const Chat: React.FC<ChatProps> = ({ items, onSendMessage, isLoading = false }) 
         </div>
         
         <div className="sticky bottom-0 p-4 md:px-6">
+          {renderAboveInput}
           <div className="relative">
             <div className="flex w-full items-end overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-md focus-within:border-indigo-300 dark:focus-within:border-indigo-700 focus-within:ring-2 focus-within:ring-indigo-300 dark:focus-within:ring-indigo-700 transition-all">
               <textarea
                 id="prompt-textarea"
+                ref={textareaRef}
                 tabIndex={0}
                 dir="auto"
                 rows={1}


### PR DESCRIPTION
## Summary
- add `ChatPromptSelector` client component for selecting prompts
- let `Chat` accept a prefill and custom content above the input
- allow `Assistant` to pass prompt and custom input content to `Chat`
- use the new selector in the chat page

## Testing
- `npm install --legacy-peer-deps` *(fails: ERESOLVE without legacy peer deps)*
- `npm run lint` *(fails: several lint errors)*
- `npm run type-check` *(fails: missing script)*
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_6855675f2bd883268ea307ec77285d6a