### PR TITLE
Add chat entry to header and command menu

### DIFF
--- a/components/command-menu.tsx
+++ b/components/command-menu.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
-import { Plus, Search, FileText, Tag, BarChart2, Keyboard } from "lucide-react"
+import { Plus, Search, FileText, Tag, BarChart2, Bot, Keyboard } from "lucide-react"
 
 import {
   CommandDialog,
@@ -67,6 +67,10 @@ export function CommandMenu() {
             <CommandItem onSelect={() => runCommand(() => router.push("/?tab=dashboard"))}>
               <BarChart2 className="mr-2 h-4 w-4" />
               <span>Dashboard</span>
+            </CommandItem>
+            <CommandItem onSelect={() => runCommand(() => router.push("/chat"))}>
+              <Bot className="mr-2 h-4 w-4" />
+              <span>Chat</span>
             </CommandItem>
             <CommandItem onSelect={() => runCommand(() => router.push("/categories"))}>
               <Tag className="mr-2 h-4 w-4" />

--- a/components/layout/global-header.tsx
+++ b/components/layout/global-header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { FileText, BarChart2, Tag, Plus, Menu } from "lucide-react"
+import { FileText, BarChart2, Tag, Bot, Plus, Menu } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { ThemeToggle } from "@/components/theme/theme-toggle"
 import { CommandMenu } from "@/components/command-menu"
@@ -24,6 +24,11 @@ export function GlobalHeader() {
       name: "Dashboard",
       path: "/?tab=dashboard",
       icon: BarChart2,
+    },
+    {
+      name: "Chat",
+      path: "/chat",
+      icon: Bot,
     },
     {
       name: "Categories",


### PR DESCRIPTION
## Summary
- include a Chat route in `GlobalHeader`
- enable jumping to `/chat` from the command menu

## Testing
- `npm run lint` *(fails: various ESLint errors)*
- `npm run type-check` *(fails: missing script)*
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_68556760b53483268128a0706dbb317b