### PR TITLE
Add chat prompt selector component

### DIFF
--- a/app/chat/ChatPageClient.tsx
+++ b/app/chat/ChatPageClient.tsx
@@ -7,6 +7,7 @@ import { ThemeToggle } from "@/components/theme/theme-toggle"
 import ContextPanel from "@/components/tools-panel" // Corrected: ToolsPanel is default export named ContextPanel
 import { useState } from "react"
 import Assistant from "@/components/assistant" // Added import for Assistant
+import ChatPromptSelector from "@/components/chat-prompt-selector"
 
 // Header component for the app
 const AppHeader = () => (
@@ -117,7 +118,8 @@ export default function ChatPageClient({ initialPrompt }: ChatPageClientProps) {
 
       {/* Main Content */}
       <div className="flex flex-1 w-full max-w-7xl mx-auto shadow-sm border border-gray-200 dark:border-gray-700 rounded-lg my-4 overflow-hidden">
-        <div className="w-full md:w-[70%] border-r border-gray-100 dark:border-gray-800">
+        <div className="w-full md:w-[70%] border-r border-gray-100 dark:border-gray-800 flex flex-col">
+          <ChatPromptSelector />
           <Assistant initialInputMessage={initialPrompt} />
         </div>
         <div className="hidden md:block w-[30%] bg-white dark:bg-gray-900">

--- a/components/chat-prompt-selector.tsx
+++ b/components/chat-prompt-selector.tsx
@@ -1,0 +1,100 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { getPrompts, type LegalPrompt } from "@/app/actions"
+import { Combobox } from "@/components/ui/combobox"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import { Switch } from "@/components/ui/switch"
+import { Label } from "@/components/ui/label"
+import { useFavorites } from "@/components/favorites-provider"
+
+export function ChatPromptSelector() {
+  const [prompts, setPrompts] = useState<LegalPrompt[]>([])
+  const [category, setCategory] = useState<string>("all")
+  const [selectedPrompt, setSelectedPrompt] = useState<string>("")
+  const [showFavoritesOnly, setShowFavoritesOnly] = useState(false)
+  const { isFavorite } = useFavorites()
+
+  useEffect(() => {
+    getPrompts().then(({ prompts }) => setPrompts(prompts))
+  }, [])
+
+  const categories = Array.from(
+    new Set(prompts.map((p) => p.category).filter(Boolean)),
+  )
+
+  const filteredPrompts = prompts.filter((p) => {
+    if (category !== "all" && p.category !== category) return false
+    if (showFavoritesOnly && !isFavorite(p.id)) return false
+    return true
+  })
+
+  const handlePromptSelect = (value: string) => {
+    setSelectedPrompt(value)
+    const prompt = prompts.find((p) => String(p.id) === value)
+    if (!prompt) return
+    const textarea = document.getElementById(
+      "prompt-textarea",
+    ) as HTMLTextAreaElement | null
+    if (textarea) {
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      )?.set
+      setter?.call(textarea, prompt.prompt)
+      const ev = new Event("input", { bubbles: true })
+      textarea.dispatchEvent(ev)
+    }
+  }
+
+  return (
+    <div className="p-4 border-b border-gray-200 dark:border-gray-800 space-y-2">
+      <div className="flex flex-wrap items-center gap-2">
+        <Combobox
+          options={filteredPrompts.map((p) => ({
+            value: String(p.id),
+            label: p.name,
+          }))}
+          value={selectedPrompt}
+          onChange={handlePromptSelect}
+          placeholder="Select a prompt"
+          className="w-64"
+          disabled={filteredPrompts.length === 0}
+        />
+        {categories.length > 1 && (
+          <Select value={category} onValueChange={setCategory}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Category" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All</SelectItem>
+              {categories.map((cat) => (
+                <SelectItem key={cat} value={cat}>
+                  {cat}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+        <div className="ml-auto flex items-center space-x-2">
+          <Label htmlFor="fav-switch" className="text-sm">
+            Favorites
+          </Label>
+          <Switch
+            id="fav-switch"
+            checked={showFavoritesOnly}
+            onCheckedChange={setShowFavoritesOnly}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ChatPromptSelector


### PR DESCRIPTION
## Summary
- create `ChatPromptSelector` client component to load prompts
- inject selector above chat input on the chat page

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: unused vars and other lint errors)*
- `npm run type-check` *(fails: missing script)*
- `npm test` *(fails: missing script)*
- `npm run build` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_68556b10f44883268a7505e7da763a0a