### PR TITLE
Improve chat layout

### DIFF
--- a/app/chat/ChatPageClient.tsx
+++ b/app/chat/ChatPageClient.tsx
@@ -130,12 +130,12 @@ export default function ChatPageClient({ initialPrompt }: ChatPageClientProps) {
 
       {/* Main Content */}
       <div className="flex flex-1 w-full max-w-7xl mx-auto shadow-sm border border-gray-200 dark:border-gray-700 rounded-lg my-4 overflow-hidden">
-        <div className="w-full md:w-[70%] border-r border-gray-100 dark:border-gray-800 flex flex-col">
+        <div className="w-full md:w-2/3 border-r border-gray-100 dark:border-gray-800 flex flex-col px-4 md:px-6">
           <ChatPromptSelector />
           <Assistant initialInputMessage={initialPrompt} />
           <PromptPicker open={pickerOpen} onOpenChange={setPickerOpen} />
         </div>
-        <div className="hidden md:block w-[30%] bg-white dark:bg-gray-900">
+        <div className="hidden md:block w-full md:w-1/3 bg-white dark:bg-gray-900 px-4 md:px-6">
           <ConfigPanelHeader />
           <ContextPanel />
         </div>

--- a/components/chat-prompt-selector.tsx
+++ b/components/chat-prompt-selector.tsx
@@ -50,7 +50,7 @@ export function ChatPromptSelector() {
   }
 
   return (
-    <div className="p-4 border-b border-gray-200 dark:border-gray-800 space-y-2">
+    <div className="sticky top-0 z-10 bg-background/95 backdrop-blur p-4 border-b border-gray-200 dark:border-gray-800 space-y-2">
       <div className="flex flex-wrap items-center gap-2">
         <Combobox
           options={filteredPrompts.map((p) => ({

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -17,7 +17,8 @@ interface ChatProps {
 }
 
 const Chat: React.FC<ChatProps> = ({ items, onSendMessage, isLoading = false, initialInputMessage = "" }) => {
-  const itemsEndRef = useRef<HTMLDivElement>(null);
+  const itemsEndRef = useRef<HTMLDivElement>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [inputMessageText, setinputMessageText] = useState<string>(initialInputMessage);
   // This state is used to provide better user experience for non-English IMEs such as Japanese
   const [isComposing, setIsComposing] = useState(false);
@@ -56,10 +57,14 @@ const Chat: React.FC<ChatProps> = ({ items, onSendMessage, isLoading = false, in
     scrollToBottom();
   }, [items]);
 
+  useEffect(() => {
+    textareaRef.current?.focus()
+  }, [])
+
   return (
     <div className="flex justify-center items-center size-full">
       <div className="flex grow flex-col h-full max-w-[750px] gap-2">
-        <div className="h-[calc(90vh-100px)] overflow-y-scroll px-4 md:px-6 flex flex-col scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-transparent">
+        <div className="flex-1 min-h-0 overflow-y-auto px-4 md:px-6 flex flex-col scrollbar-thin scrollbar-thumb-gray-300 dark:scrollbar-thumb-gray-600 scrollbar-track-transparent">
           <div className="mt-auto space-y-2 py-4">
             {items.length === 0 && (
               <div className="flex flex-col items-center justify-center text-center p-8 my-8">
@@ -118,6 +123,7 @@ const Chat: React.FC<ChatProps> = ({ items, onSendMessage, isLoading = false, in
             <div className="flex w-full items-end overflow-hidden rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-md focus-within:border-indigo-300 dark:focus-within:border-indigo-700 focus-within:ring-2 focus-within:ring-indigo-300 dark:focus-within:ring-indigo-700 transition-all">
               <textarea
                 id="prompt-textarea"
+                ref={textareaRef}
                 tabIndex={0}
                 dir="auto"
                 rows={1}

--- a/components/chat.tsx
+++ b/components/chat.tsx
@@ -17,8 +17,8 @@ interface ChatProps {
 }
 
 const Chat: React.FC<ChatProps> = ({ items, onSendMessage, isLoading = false, initialInputMessage = "" }) => {
-  const itemsEndRef = useRef<HTMLDivElement>(null)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const itemsEndRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const [inputMessageText, setinputMessageText] = useState<string>(initialInputMessage);
   // This state is used to provide better user experience for non-English IMEs such as Japanese
   const [isComposing, setIsComposing] = useState(false);
@@ -58,8 +58,8 @@ const Chat: React.FC<ChatProps> = ({ items, onSendMessage, isLoading = false, in
   }, [items]);
 
   useEffect(() => {
-    textareaRef.current?.focus()
-  }, [])
+    textareaRef.current?.focus();
+  }, []);
 
   return (
     <div className="flex justify-center items-center size-full">


### PR DESCRIPTION
## Summary
- make chat height flexible
- keep prompt selector visible with sticky position
- focus chat input on load for convenience

## Testing
- `npm run lint` *(fails: many unused vars)*
- `npm run type-check` *(fails: type errors in ai service)*
- `npm test`
- `npm run build` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_6856c0dcd13c832698a3ade81f78deac