### PR TITLE
fix: responsive mobile panel

### DIFF
--- a/app/chat/ChatPageClient.tsx
+++ b/app/chat/ChatPageClient.tsx
@@ -33,7 +33,7 @@ interface MobileToolsPanelProps {
 const MobileToolsPanel = ({ isOpen, onClose }: MobileToolsPanelProps) =>
   isOpen ? (
     <div className="fixed inset-0 z-50 flex justify-end bg-black bg-opacity-30 backdrop-blur-sm md:hidden">
-      <div className="w-[85%] bg-white dark:bg-gray-900 h-full shadow-lg animate-slide-in-from-right">
+      <div className="w-11/12 max-w-sm bg-white dark:bg-gray-900 h-full shadow-lg animate-slide-in-from-right">
         <div className="p-4 border-b border-gray-100 dark:border-gray-800 flex justify-between items-center">
           <h2 className="text-lg font-medium text-foreground flex items-center">
             <SparklesIcon size={16} className="text-indigo-600 dark:text-indigo-400 mr-2" />


### PR DESCRIPTION
## Summary
- adjust mobile tools panel width using standard Tailwind classes

## Testing
- `npm run lint` *(fails: unused vars and react issues)*
- `npm run type-check` *(fails: OpenAI types)*
- `npm test`
- `npm run build` *(fails: missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_6858103635b08326a280d41988dbcd3a