### PR TITLE
Fix global font loading

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,7 +5,7 @@
 @import "./theme-vars.css";
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- use Inter variable for default font

## Testing
- `npm run lint` *(fails: unused vars and other lint errors)*
- `npm run type-check` *(fails: TS errors)*
- `npm test`
- `npm run build` *(fails: missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68581ce294dc8326af512146bbab0d48