### PR TITLE
Remove hard-coded colors

### DIFF
--- a/components/dashboard-stats.tsx
+++ b/components/dashboard-stats.tsx
@@ -225,7 +225,7 @@ export function DashboardStats() {
                         contentStyle={{
                           borderRadius: "8px",
                           border: "1px solid hsl(var(--border))",
-                          boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+                          boxShadow: "0 4px 6px -1px hsl(var(--foreground) / 0.1)",
                         }}
                       />
                       <Bar dataKey="value" fill="hsl(var(--primary))" radius={[0, 4, 4, 0]} barSize={20} />
@@ -270,7 +270,7 @@ export function DashboardStats() {
                       contentStyle={{
                         borderRadius: "8px",
                         border: "1px solid hsl(var(--border))",
-                        boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+                        boxShadow: "0 4px 6px -1px hsl(var(--foreground) / 0.1)",
                       }}
                     />
                   </PieChart>
@@ -296,7 +296,7 @@ export function DashboardStats() {
                       contentStyle={{
                         borderRadius: "8px",
                         border: "1px solid hsl(var(--border))",
-                        boxShadow: "0 4px 6px -1px rgba(0, 0, 0, 0.1)",
+                        boxShadow: "0 4px 6px -1px hsl(var(--foreground) / 0.1)",
                       }}
                     />
                     <Legend />

--- a/components/enhanced-dashboard.tsx
+++ b/components/enhanced-dashboard.tsx
@@ -281,7 +281,7 @@ export function EnhancedDashboard() {
                         ) : (
                           <ResponsiveContainer width="100%" height="100%">
                             <LineChart data={categoryData} margin={{ left: 20, right: 20 }}>
-                              <CartesianGrid strokeDasharray="3 3" />
+                              <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
                               <XAxis dataKey="name" />
                               <YAxis />
                               <Tooltip />
@@ -321,7 +321,7 @@ export function EnhancedDashboard() {
                           </defs>
                           <XAxis dataKey="month" />
                           <YAxis />
-                          <CartesianGrid strokeDasharray="3 3" />
+                          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
                           <Tooltip />
                           <Legend />
                           <Area
@@ -355,7 +355,7 @@ export function EnhancedDashboard() {
                     <div className="h-80">
                       <ResponsiveContainer width="100%" height="100%">
                         <BarChart data={PROMPT_ACTIVITY} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-                          <CartesianGrid strokeDasharray="3 3" />
+                          <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
                           <XAxis dataKey="date" />
                           <YAxis />
                           <Tooltip />

--- a/components/prompt-analytics.tsx
+++ b/components/prompt-analytics.tsx
@@ -217,7 +217,7 @@ export function PromptAnalytics({ promptId }: PromptAnalyticsProps) {
                 <div className="h-80">
                   <ResponsiveContainer width="100%" height="100%">
                     <LineChart data={analytics.usageOverTime} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
-                      <CartesianGrid strokeDasharray="3 3" />
+                      <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
                       <XAxis dataKey="date" />
                       <YAxis />
                       <Tooltip />
@@ -246,7 +246,7 @@ export function PromptAnalytics({ promptId }: PromptAnalyticsProps) {
                 <div className="h-64">
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart data={analytics.usageByTime} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
-                      <CartesianGrid strokeDasharray="3 3" />
+                      <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
                       <XAxis dataKey="hour" />
                       <YAxis />
                       <Tooltip />
@@ -266,7 +266,7 @@ export function PromptAnalytics({ promptId }: PromptAnalyticsProps) {
                 <div className="h-64">
                   <ResponsiveContainer width="100%" height="100%">
                     <BarChart data={analytics.usageByDay} margin={{ top: 5, right: 30, left: 20, bottom: 5 }}>
-                      <CartesianGrid strokeDasharray="3 3" />
+                      <CartesianGrid strokeDasharray="3 3" stroke="hsl(var(--border))" />
                       <XAxis dataKey="day" />
                       <YAxis />
                       <Tooltip />

--- a/components/tool-call.tsx
+++ b/components/tool-call.tsx
@@ -47,7 +47,7 @@ function ApiCallCell({ toolCall }: ToolCallProps) {
                     marginBottom: 8,
                     fontSize: "12px",
                     backgroundColor: "hsl(var(--background))", // Dark background regardless of mode
-                    border: "1px solid rgba(82, 82, 89, 0.32)"
+                    border: "1px solid hsl(var(--muted-foreground) / 0.32)"
                   }}
                   language="json"
                   style={vscDarkPlus}
@@ -69,7 +69,7 @@ function ApiCallCell({ toolCall }: ToolCallProps) {
                       marginBottom: 0,
                       fontSize: "12px",
                       backgroundColor: "hsl(var(--background))", // Dark background regardless of mode
-                      border: "1px solid rgba(82, 82, 89, 0.32)"
+                      border: "1px solid hsl(var(--muted-foreground) / 0.32)"
                     }}
                     language="json"
                     style={vscDarkPlus}

--- a/components/ui/chart.tsx
+++ b/components/ui/chart.tsx
@@ -52,7 +52,7 @@ const ChartContainer = React.forwardRef<
         data-chart={chartId}
         ref={ref}
         className={cn(
-          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot]:stroke-transparent [&_.recharts-layer]:outline-none [&_.recharts-polar-grid_]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_]:stroke-border [&_.recharts-sector]:stroke-transparent [&_.recharts-sector]:outline-none [&_.recharts-surface]:outline-none",
           className
         )}
         {...props}


### PR DESCRIPTION
## Summary
- replace inline border/boxShadow colors with theme variables
- standardize Recharts grid colors across components
- simplify chart component selectors to remove literal hex references

## Testing
- `npm run lint` *(fails: 'promptId' is defined but never used, etc.)*
- `npm run type-check` *(fails: Type errors in ai-service.ts and openai.ts)*
- `npm test`
- `npm run build` *(fails: missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68581cc274e4832694716944d89d3d00