### PR TITLE
Type prompt filter fields

### DIFF
--- a/components/prompt-filters.tsx
+++ b/components/prompt-filters.tsx
@@ -8,14 +8,22 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { useTags } from "@/components/tags-provider"
 
+interface PromptFilterFields {
+  category?: string[]
+  dateRange?: {
+    from?: string
+    to?: string
+  }
+}
+
 interface PromptFiltersProps {
   selectedCategories: string[]
   onCategoryChange: (categories: string[]) => void
   selectedTags: string[]
   onTagChange: (tags: string[]) => void
   categories: string[]
-  filters: any // TODO: Define type
-  onFilterChange: (filters: any) => void // TODO: Define type
+  filters: PromptFilterFields
+  onFilterChange: (filters: PromptFilterFields) => void
 }
 
 export function PromptFilters({


### PR DESCRIPTION
## Summary
- add PromptFilterFields interface
- use PromptFilterFields in PromptFilters component

## Testing
- `npm run lint` *(fails: unused vars and react warnings)*
- `npm run type-check` *(fails: numerous type errors)*
- `npm test`
- `npm run build` *(fails: missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68581ce64b808326a22d30cf85f4c439