### PR TITLE
Use local Geist fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,11 @@ This project combines the features of a general AI assistant starter app with fu
 - **TypeScript** - Type safety and improved developer experience
 - **TailwindCSS** - Utility-first CSS framework
 - **OpenAI API** - Powerful AI model integration
-- **Zustand** - State management 
+- **Zustand** - State management
 - **React Dropzone** - File upload functionality
 - **React Markdown** - Rich text rendering
 - **Lucide Icons** - Beautiful, consistent icon set
+- **Geist & Geist Mono Fonts** - Local variable fonts loaded with `next/font/local`
 
 ## 🛠️ Getting Started
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type React from "react"
-import { Inter } from "next/font/google"
+import localFont from "next/font/local"
 import "@/styles/globals.css"
 import { ThemeProvider } from "@/components/theme-provider"
 import { FavoritesProvider } from "@/components/favorites-provider"
@@ -7,10 +7,15 @@ import { TagsProvider } from "@/components/tags-provider"
 import { GlobalHeader } from "@/components/layout/global-header"
 import { GlobalFooter } from "@/components/layout/global-footer"
 
-// Use variable font with more weights
-const inter = Inter({
-  subsets: ["latin"],
+// Load local Geist fonts
+const geist = localFont({
+  src: "./fonts/GeistVF.woff",
   variable: "--font-sans",
+  display: "swap",
+})
+const geistMono = localFont({
+  src: "./fonts/GeistMonoVF.woff",
+  variable: "--font-mono",
   display: "swap",
 })
 
@@ -22,7 +27,7 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" suppressHydrationWarning className={`${inter.variable} antialiased`}>
+    <html lang="en" suppressHydrationWarning className={`${geist.variable} ${geistMono.variable} antialiased`}>
       <body className="min-h-screen bg-background font-sans">
         <ThemeProvider
           attribute="class"


### PR DESCRIPTION
## Summary
- load Geist and Geist Mono with `next/font/local`
- document font usage

## Testing
- `npm run lint` (fails: unused vars)
- `npm run type-check` (fails: type errors)
- `npm test`
- `npm run build` *(fails: missing OPENAI_API_KEY)*

------
https://chatgpt.com/codex/tasks/task_e_68581ce5c2f083268a3d237c459678b4