### PR TITLE
Add fallback prompts and logging for chat selector

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -552,6 +552,50 @@ export async function getCategories(): Promise<string[]> {
   }
 }
 
+export async function addCategory(name: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    await sql`
+      INSERT INTO legalprompt (name, prompt, category, "systemMessage")
+      VALUES ('Category Template', 'Template for category', ${name}, NULL)
+    `
+    return { success: true }
+  } catch (e: unknown) {
+    const error = e instanceof Error ? e : new Error(String(e))
+    console.error("Error adding category:", error)
+    return { success: false, error: error.message }
+  }
+}
+
+export async function renameCategory(oldName: string, newName: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    await sql`
+      UPDATE legalprompt
+      SET category = ${newName}
+      WHERE category = ${oldName}
+    `
+    return { success: true }
+  } catch (e: unknown) {
+    const error = e instanceof Error ? e : new Error(String(e))
+    console.error("Error renaming category:", error)
+    return { success: false, error: error.message }
+  }
+}
+
+export async function deleteCategory(name: string): Promise<{ success: boolean; error?: string }> {
+  try {
+    await sql`
+      UPDATE legalprompt
+      SET category = 'Uncategorized'
+      WHERE category = ${name}
+    `
+    return { success: true }
+  } catch (e: unknown) {
+    const error = e instanceof Error ? e : new Error(String(e))
+    console.error("Error deleting category:", error)
+    return { success: false, error: error.message }
+  }
+}
+
 
 export async function getPromptStats(): Promise<{
   total: number

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -378,7 +378,8 @@ export async function updateLegalPrompt(
       SET name = ${sanitizedData.name},
           prompt = ${sanitizedData.prompt},
           category = ${sanitizedData.category},
-          "systemMessage" = ${sanitizedData.systemMessage}
+          "systemMessage" = ${sanitizedData.systemMessage},
+          "updatedAt" = NOW()
       WHERE id = ${id}
       RETURNING id, name, prompt, category, "systemMessage", "createdAt", "updatedAt"
     `

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -31,7 +31,9 @@ export type PromptError = {
 export async function getPrompts(): Promise<{ prompts: LegalPrompt[]; error: string | null }> {
   try {
     // When the database connection isn't configured, fall back to bundled prompt data
-    if (!process.env.DATABASE_URL) {
+    // Access the variable dynamically so its value is read at runtime. Next.js
+    // may inline environment variables if dot notation is used.
+    if (!process.env["DATABASE_URL"]) {
       console.warn("DATABASE_URL is not set. Loading fallback prompts")
       const prompts: LegalPrompt[] = (fallbackPrompts as any[]).map((p, i) => ({
         id: i + 1,

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -374,14 +374,16 @@ export async function updateLegalPrompt(
     }
 
     const result = await sql`
-      UPDATE legalprompt 
-      SET name = ${sanitizedData.name}, 
-          prompt = ${sanitizedData.prompt}, 
-          category = ${sanitizedData.category}, 
+      UPDATE legalprompt
+      SET name = ${sanitizedData.name},
+          prompt = ${sanitizedData.prompt},
+          category = ${sanitizedData.category},
           "systemMessage" = ${sanitizedData.systemMessage}
-      WHERE id = ${id} 
+      WHERE id = ${id}
       RETURNING id, name, prompt, category, "systemMessage", "createdAt", "updatedAt"
     `
+
+    console.log(`Updated prompt ${id}`, result[0])
     
     const updatedPrompt = result[0]
 

--- a/app/api/prompts/route.ts
+++ b/app/api/prompts/route.ts
@@ -1,0 +1,9 @@
+"use server"
+
+import { NextResponse } from "next/server"
+import { getPrompts } from "@/app/actions"
+
+export async function GET() {
+  const result = await getPrompts()
+  return NextResponse.json(result)
+}

--- a/components/category-manager.tsx
+++ b/components/category-manager.tsx
@@ -17,7 +17,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { sql } from "@/lib/db"
+import {
+  addCategory,
+  renameCategory,
+  deleteCategory,
+} from "@/app/actions"
 import { motion, AnimatePresence } from "framer-motion"
 
 interface CategoryManagerProps {
@@ -36,11 +40,10 @@ export function CategoryManager({ initialCategories }: CategoryManagerProps) {
     if (!newCategory.trim()) return
 
     try {
-      // This is a simplified approach - in a real app, you might want to create a proper categories table
-      await sql`
-        INSERT INTO legalprompt (name, prompt, category, "systemMessage")
-        VALUES ('Category Template', 'Template for category', ${newCategory}, NULL)
-      `
+      const result = await addCategory(newCategory)
+      if (!result.success) {
+        throw new Error(result.error)
+      }
 
       setCategories([...categories, newCategory])
       setNewCategory("")
@@ -68,12 +71,10 @@ export function CategoryManager({ initialCategories }: CategoryManagerProps) {
     const oldCategory = categories[index]
 
     try {
-      // Update all prompts with the old category
-      await sql`
-        UPDATE legalprompt
-        SET category = ${editValue}
-        WHERE category = ${oldCategory}
-      `
+      const result = await renameCategory(oldCategory, editValue)
+      if (!result.success) {
+        throw new Error(result.error)
+      }
 
       const newCategories = [...categories]
       newCategories[index] = editValue
@@ -101,12 +102,10 @@ export function CategoryManager({ initialCategories }: CategoryManagerProps) {
     const categoryToDelete = categories[deleteIndex]
 
     try {
-      // Update prompts to use a default category
-      await sql`
-        UPDATE legalprompt
-        SET category = 'Uncategorized'
-        WHERE category = ${categoryToDelete}
-      `
+      const result = await deleteCategory(categoryToDelete)
+      if (!result.success) {
+        throw new Error(result.error)
+      }
 
       const newCategories = categories.filter((_, i) => i !== deleteIndex)
       setCategories(newCategories)

--- a/components/chat-prompt-selector.tsx
+++ b/components/chat-prompt-selector.tsx
@@ -31,6 +31,10 @@ export function ChatPromptSelector() {
     return true
   })
 
+  if (filteredPrompts.length === 0) {
+    console.warn("ChatPromptSelector: no prompts available to display")
+  }
+
   const handlePromptSelect = (value: string) => {
     setSelectedPrompt(value)
     const prompt = prompts.find((p) => String(p.id) === value)

--- a/components/edit-prompt-form.tsx
+++ b/components/edit-prompt-form.tsx
@@ -60,13 +60,19 @@ export function EditPromptForm({ prompt }: EditPromptFormProps) {
     setIsSubmitting(true)
 
     try {
-      await updateLegalPrompt(prompt.id, {
+      const result = await updateLegalPrompt(prompt.id, {
         name: formData.name,
         category: formData.category,
         prompt: formData.prompt,
         systemMessage: formData.systemMessage || null,
         tags: tags,
       })
+
+      console.log("updateLegalPrompt result", result)
+
+      if (!result.success) {
+        throw new Error(result.error?.message || "Update failed")
+      }
 
       toast({
         title: "Success",

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -124,3 +124,7 @@ Endpoints for managing OpenAI vector stores.
 - **`/api/vector_stores/list_files`** – GET: list files in a vector store (provide `vector_store_id` query param).
 - **`/api/vector_stores/retrieve_store`** – GET: retrieve store metadata by ID.
 
+### `/api/prompts` – GET
+Return all prompts with fallback data when the database is unavailable. Used by
+client hooks to populate prompt selectors.
+

--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -48,7 +48,8 @@ if (result.success) {
 Update an existing prompt with standard form data and redirect.
 
 #### `updateLegalPrompt(id: number, data)`
-Update a prompt using a typed object. Returns the updated record on success.
+Update a prompt using a typed object. Returns the updated record on success and
+sets the `updatedAt` timestamp to the current time.
 
 #### `deletePrompt(id: number)`
 Remove a prompt and redirect to the home page.

--- a/hooks/use-prompts.ts
+++ b/hooks/use-prompts.ts
@@ -1,14 +1,19 @@
 import { useEffect, useState } from "react"
-import { getPrompts, type LegalPrompt } from "@/app/actions"
+import type { LegalPrompt } from "@/app/actions"
 
 export function usePrompts() {
   const [prompts, setPrompts] = useState<LegalPrompt[]>([])
 
   useEffect(() => {
-    getPrompts().then(({ prompts }) => {
-      console.log(`usePrompts loaded ${prompts.length} prompts`)
-      setPrompts(prompts)
-    })
+    fetch("/api/prompts")
+      .then(res => res.json())
+      .then((data: { prompts: LegalPrompt[] }) => {
+        console.log(`usePrompts loaded ${data.prompts.length} prompts`)
+        setPrompts(data.prompts)
+      })
+      .catch(err => {
+        console.error("Failed to load prompts", err)
+      })
   }, [])
 
   return { prompts }

--- a/hooks/use-prompts.ts
+++ b/hooks/use-prompts.ts
@@ -5,7 +5,10 @@ export function usePrompts() {
   const [prompts, setPrompts] = useState<LegalPrompt[]>([])
 
   useEffect(() => {
-    getPrompts().then(({ prompts }) => setPrompts(prompts))
+    getPrompts().then(({ prompts }) => {
+      console.log(`usePrompts loaded ${prompts.length} prompts`)
+      setPrompts(prompts)
+    })
   }, [])
 
   return { prompts }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -2,22 +2,32 @@ import { neon } from "@neondatabase/serverless"
 import { drizzle } from "drizzle-orm/neon-http"
 import * as schema from "./db/schema"
 
-// Make sure we're using the DATABASE_URL environment variable
-// The error suggests this might not be properly set or accessed
+// Read the database URL from the environment. Some development setups may omit
+// this variable, so we provide a graceful fallback rather than throwing during
+// import which would break server actions.
 const DATABASE_URL = process.env.DATABASE_URL || process.env.POSTGRES_URL
 
+let sql: ReturnType<typeof neon> | ((...args: any[]) => Promise<unknown[]>)
+let db: ReturnType<typeof drizzle> | null
+
 if (!DATABASE_URL) {
-  throw new Error("DATABASE_URL environment variable is not set. Please configure your database connection.")
+  console.warn(
+    "DATABASE_URL is not set. Database features are disabled; using mock client.",
+  )
+  // Provide a mock sql function so calls fail gracefully
+  sql = async (..._args: any[]) => {
+    console.warn("Mock SQL called with:", _args[0])
+    return []
+  }
+  db = null
+} else {
+  const neonClient = neon(DATABASE_URL)
+  sql = neonClient
+  db = drizzle(neonClient, { schema })
 }
 
-// Create a SQL query executor using the Neon serverless driver
-const neonClient = neon(DATABASE_URL)
-
-// Create a drizzle instance with the neon client and our schema
-export const db = drizzle(neonClient, { schema })
-
-// Export the sql tagged template function from drizzle-orm
-export { neonClient as sql }
+// Export the sql tagged template function and db instance (may be null)
+export { sql, db }
 
 // Helper function with timeout
 export async function executeQueryWithTimeout<T>(queryFn: () => Promise<T>, timeout = 10000): Promise<T> {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -5,7 +5,11 @@ import * as schema from "./db/schema"
 // Read the database URL from the environment. Some development setups may omit
 // this variable, so we provide a graceful fallback rather than throwing during
 // import which would break server actions.
-const DATABASE_URL = process.env.DATABASE_URL || process.env.POSTGRES_URL
+// Use bracket notation so Next.js doesn't inline the value at build time.
+// This ensures the variable is read at runtime and works in deployed
+// environments like Vercel where the value may differ between build and
+// runtime.
+const DATABASE_URL = process.env["DATABASE_URL"] || process.env["POSTGRES_URL"]
 
 let sql: ReturnType<typeof neon> | ((...args: any[]) => Promise<unknown[]>)
 let db: ReturnType<typeof drizzle> | null

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -11,6 +11,10 @@ import * as schema from "./db/schema"
 // runtime.
 const DATABASE_URL = process.env["DATABASE_URL"] || process.env["POSTGRES_URL"]
 
+if (DATABASE_URL) {
+  console.log("DATABASE_URL detected for database client")
+}
+
 let sql: ReturnType<typeof neon> | ((...args: any[]) => Promise<unknown[]>)
 let db: ReturnType<typeof drizzle> | null
 

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,7 +1,9 @@
 // Environment variables with type safety
 export const env = {
-  DATABASE_URL: process.env.DATABASE_URL || "",
-  NODE_ENV: process.env.NODE_ENV || "development",
+  // Use bracket notation to avoid build-time replacement in Next.js. This
+  // ensures the value is read from the environment at runtime.
+  DATABASE_URL: process.env["DATABASE_URL"] || "",
+  NODE_ENV: process.env["NODE_ENV"] || "development",
 }
 
 // Validate required environment variables


### PR DESCRIPTION
## Summary
- provide mock DB client when `DATABASE_URL` isn't set
- load prompts from `prompts-data.json` when the DB is unavailable
- log prompt loading in `usePrompts` and `ChatPromptSelector`

## Testing
- `npm run lint` *(fails: numerous unrelated lint errors)*
- `npm run type-check` *(fails: existing type errors)*
- `npm test`
- `npm run build` *(fails: OPENAI_API_KEY missing)*

------
https://chatgpt.com/codex/tasks/task_e_685823f56c748326a32a1bc0dde7a67c